### PR TITLE
Parse TurnServerExpiery Parameter Before Concatenating

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -111,7 +111,7 @@ module.exports = function (server, config) {
             config.turnservers.forEach(function (server) {
                 var hmac = crypto.createHmac('sha1', server.secret);
                 // default to 86400 seconds timeout unless specified
-                var username = Math.floor(new Date().getTime() / 1000) + (server.expiry || 86400) + "";
+                var username = Math.floor(new Date().getTime() / 1000) + (parseInt(server.expiry, 10) || 86400) + "";
                 hmac.update(username);
                 credentials.push({
                     username: username,


### PR DESCRIPTION
When using Env Varibles with docker getConfig identifies parameters as strings. Since Expiery variable is an int, it should be parsed